### PR TITLE
:bug: Fix peertube channels with multiple thumbnails per video

### DIFF
--- a/tf_platform_peertube/examples/pt_channel.rs
+++ b/tf_platform_peertube/examples/pt_channel.rs
@@ -23,8 +23,8 @@ use std::error::Error;
 use tf_core::{ErrorStore, GeneratorWithClient, Video};
 use tf_pt::{PTSubscription, PTVideo};
 
-const BASE_URL: &str = "https://peertube.linuxrocks.online";
-const ID: &str = "techlore_channel@tube.privacytools.io";
+const BASE_URL: &str = "https://tilvids.com";
+const ID: &str = "thelinuxexperiment_channel@tilvids.com";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/tf_platform_peertube/src/video.rs
+++ b/tf_platform_peertube/src/video.rs
@@ -149,7 +149,12 @@ impl FromItemAndSub<PTSubscription> for PTVideo {
             url: i.link,
             uploaded: i.pub_date,
             subscription: sub,
-            thumbnail_url: i.media_thumbnail.url,
+            thumbnail_url: i
+                .media_thumbnail
+                .into_iter()
+                .next()
+                .map(|m| m.url)
+                .unwrap_or_default(),
         }
     }
 }

--- a/tf_utils/src/rss/structure.rs
+++ b/tf_utils/src/rss/structure.rs
@@ -51,7 +51,7 @@ pub struct Item {
 
     #[serde(rename = "media/thumbnail")]
     #[serde(default)]
-    pub media_thumbnail: MediaThumbnail,
+    pub media_thumbnail: Vec<MediaThumbnail>,
     #[serde(rename = "itunes/image")]
     #[serde(default)]
     pub itunes_image: ItunesImage,


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

Some channels that publish multiple thumbnails per video did not work:

<https://tilvids.com/c/thelinuxexperiment_channel/videos>

# Linked Issue

As noted in the matrix room.